### PR TITLE
Add Field Manuals FM-1 through FM-6

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ The Starfall Defence Corps Academy is a structured training programme that teach
 | 2.4 | Defence in Depth | CI/CD pipelines, ansible-lint, drift detection | [mission-2-4-defence-in-depth](https://github.com/starfall-defence-corps/mission-2-4-defence-in-depth) |
 | **Master** | **Operation: Iron Curtain** | **Capstone assessment — all Module 2 skills, 3.5 hr** | [master-simulation](https://github.com/starfall-defence-corps/master-simulation) |
 
+### Field Manuals — Reference Library
+
+| Manual | Topic |
+|--------|-------|
+| [FM-1](field-manuals/FM-1-ansible-reference.md) | Ansible Module Reference — blue team module cards |
+| [FM-2](field-manuals/FM-2-yaml-jinja2-reference.md) | YAML & Jinja2 Quick Reference |
+| [FM-3](field-manuals/FM-3-molecule-testing-reference.md) | Molecule & Testing Reference |
+| [FM-4](field-manuals/FM-4-cis-compliance-reference.md) | CIS & Compliance Reference |
+| [FM-5](field-manuals/FM-5-glossary.md) | Glossary — technical + lore terms |
+| [FM-6](field-manuals/FM-6-faq-simulation-hub.md) | FAQ & Simulation Hub |
+
 ## How to Enrol
 
 1. Navigate to your assigned mission repo (see table above)

--- a/field-manuals/FM-1-ansible-reference.md
+++ b/field-manuals/FM-1-ansible-reference.md
@@ -1,0 +1,726 @@
+# FM-1: Ansible Module Reference
+> Starfall Defence Corps -- Field Manual
+
+Classification: UNCLASSIFIED // Training Use Only
+Revision: 1.0 | Date: 2187.04.03
+
+---
+
+This reference covers every Ansible module used across the SDC Academy curriculum. Each card provides the fully qualified collection name, a working example, the security context, and the mission where it first appears.
+
+**How to read a card**: FQCN is the canonical module name. Always use it in playbooks -- short names are ambiguous and `ansible-lint` will flag them.
+
+---
+
+## Quick Reference Table
+
+| Module | Category | First Used | Primary Security Purpose |
+|--------|----------|------------|--------------------------|
+| `ansible.builtin.file` | File Mgmt | 1.3 | Enforce permissions, ownership |
+| `ansible.builtin.copy` | File Mgmt | 1.3 | Deploy hardened config files |
+| `ansible.builtin.template` | File Mgmt | 1.4 | Generate host-specific configs |
+| `ansible.builtin.lineinfile` | File Mgmt | 1.2 | Patch single config directives |
+| `ansible.builtin.stat` | File Mgmt | 1.3 | Pre-flight file checks |
+| `ansible.builtin.service` | Services | 1.2 | Enable/disable daemons |
+| `ansible.builtin.systemd` | Services | 1.3 | Systemd-specific control |
+| `ansible.builtin.apt` | Packages | 1.3 | Debian/Ubuntu package state |
+| `ansible.builtin.dnf` | Packages | 1.3 | RHEL/Rocky package state |
+| `ansible.builtin.package` | Packages | 1.4 | OS-agnostic package control |
+| `ansible.builtin.user` | Users | 1.3 | Account provisioning/removal |
+| `ansible.builtin.group` | Users | 1.3 | Group management |
+| `community.general.ufw` | Firewall | 1.3 | Ubuntu firewall rules |
+| `ansible.posix.firewalld` | Firewall | 1.3 | RHEL firewall rules |
+| `ansible.posix.sysctl` | System | 2.2 | Kernel parameter hardening |
+| `ansible.builtin.cron` | System | 1.3 | Scheduled tasks |
+| `ansible.builtin.authorized_key` | SSH | 1.2 | SSH public key deployment |
+| `ansible.builtin.include_vars` | Vault | 1.5 | Load encrypted variable files |
+| `ansible.builtin.wait_for` | Orchestration | 2.3 | Port/service readiness checks |
+| `ansible.builtin.fail` | Orchestration | 2.3 | Controlled abort on bad state |
+| `ansible.builtin.assert` | Orchestration | 2.3 | Pre/post-condition validation |
+| `ansible.builtin.debug` | Orchestration | 1.1 | Variable inspection |
+| `ansible.builtin.shell` | Orchestration | 1.1 | Raw shell execution |
+| `ansible.builtin.command` | Orchestration | 1.1 | Process execution (no shell) |
+
+---
+
+## File Management
+
+---
+
+### `ansible.builtin.file`
+
+Set permissions, ownership, symlinks, and directory state. The backbone of filesystem hardening.
+
+**First used**: Mission 1.3 -- Clean Sweep
+
+```yaml
+- name: Lock down shadow file permissions
+  ansible.builtin.file:
+    path: /etc/shadow
+    owner: root
+    group: shadow
+    mode: "0640"
+```
+
+**Security use case**: Enforce least-privilege file permissions across the fleet. CIS benchmarks mandate specific modes on `/etc/passwd`, `/etc/shadow`, `/etc/gshadow`, and log directories.
+
+> **Common Mistakes**
+> - Omitting the leading zero or quotes on `mode`. Write `mode: "0640"`, not `mode: 640`. The bare integer `640` is interpreted as decimal, producing octal `01200` -- not what you want.
+> - Using `state: directory` when you meant `state: file`. They do different things. `state: file` modifies an existing file; `state: directory` creates a directory.
+> - Forgetting `recurse: true` when setting permissions on a directory tree.
+
+---
+
+### `ansible.builtin.copy`
+
+Deploy static files from the control node to managed hosts. For templated content, use `template` instead.
+
+**First used**: Mission 1.3 -- Clean Sweep (sysctl config files)
+
+```yaml
+- name: Deploy hardened sysctl configuration
+  ansible.builtin.copy:
+    src: files/99-sdc-hardening.conf
+    dest: /etc/sysctl.d/99-sdc-hardening.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload sysctl
+```
+
+**Security use case**: Push known-good configuration files (sysctl, limits.d, audit rules) to all ships. The source file is version-controlled, so drift is detectable.
+
+> **Common Mistakes**
+> - Using `copy` when the file needs host-specific values. If you see `{{ anything }}` in the file, you need `template`, not `copy`.
+> - Forgetting `notify` for services that need to reload after config changes.
+> - Setting `content:` and `src:` simultaneously -- they are mutually exclusive.
+
+---
+
+### `ansible.builtin.template`
+
+Render Jinja2 templates and deploy them to managed hosts. Variables are substituted at deploy time.
+
+**First used**: Mission 1.4 -- Many Ships
+
+```yaml
+- name: Deploy fleet-specific MOTD
+  ansible.builtin.template:
+    src: templates/motd.j2
+    dest: /etc/motd
+    owner: root
+    group: root
+    mode: "0644"
+```
+
+**Security use case**: Generate host-specific SSH banners, firewall rules, or config files that vary by OS, role, or environment. One template covers the entire fleet.
+
+> **Common Mistakes**
+> - Placing templates in `files/` instead of `templates/`. Ansible looks for `src:` relative to the role's `templates/` directory.
+> - Using `{{ variable }}` without quoting in YAML. If the value starts with `{`, YAML parses it as a dict. Always quote: `"{{ variable }}"`.
+> - Leaving debug `{{ vars }}` dumps in production templates.
+
+---
+
+### `ansible.builtin.lineinfile`
+
+Ensure a single line exists (or is absent) in a file. Surgical edits -- one line at a time.
+
+**First used**: Mission 1.2 -- Lock the Door (sshd_config)
+
+```yaml
+- name: Disable root SSH login
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: "^#?PermitRootLogin"
+    line: "PermitRootLogin no"
+    validate: "sshd -t -f %s"
+  notify: Restart sshd
+```
+
+**Security use case**: Patch individual directives in SSH, PAM, or login.defs without replacing the entire file. The `validate` parameter prevents deploying broken configs.
+
+> **Common Mistakes**
+> - Writing a `regexp` that matches multiple lines. `lineinfile` operates on the *last* match. If your regex is too broad, you get unpredictable edits.
+> - Forgetting `regexp` entirely -- this causes duplicate lines on every run (not idempotent).
+> - Not using `validate` on critical configs like `sshd_config`. A syntax error there locks you out.
+
+---
+
+### `ansible.builtin.stat`
+
+Check whether a file exists, its type, size, permissions, or checksum. Does not modify anything.
+
+**First used**: Mission 1.3 -- Clean Sweep
+
+```yaml
+- name: Check if legacy config exists
+  ansible.builtin.stat:
+    path: /etc/old-firewall.conf
+  register: legacy_conf
+
+- name: Remove legacy config if present
+  ansible.builtin.file:
+    path: /etc/old-firewall.conf
+    state: absent
+  when: legacy_conf.stat.exists
+```
+
+**Security use case**: Pre-flight checks before remediation. Verify a file exists before modifying it, or confirm a backup was created before overwriting.
+
+> **Common Mistakes**
+> - Accessing `stat.exists` without registering the result first.
+> - Assuming `stat.mode` returns a string. It returns an octal string like `"0644"` -- compare accordingly.
+
+---
+
+## Service Management
+
+---
+
+### `ansible.builtin.service`
+
+Manage services across init systems. Works with systemd, SysVinit, and others.
+
+**First used**: Mission 1.2 -- Lock the Door
+
+```yaml
+- name: Ensure SSH daemon is running and enabled
+  ansible.builtin.service:
+    name: sshd
+    state: started
+    enabled: true
+```
+
+**Security use case**: Ensure critical security services (sshd, auditd, fail2ban) are running. Disable unnecessary services to reduce attack surface.
+
+> **Common Mistakes**
+> - Using `state: restarted` unconditionally. This disrupts connections on every run. Use handlers with `notify` for conditional restarts.
+> - Confusing `enabled` (start on boot) with `state` (running now). You usually want both.
+
+---
+
+### `ansible.builtin.systemd`
+
+Systemd-specific service control. Supports daemon-reload, masked units, and scope.
+
+**First used**: Mission 1.3 -- Clean Sweep
+
+```yaml
+- name: Disable and mask unused service
+  ansible.builtin.systemd:
+    name: cups
+    state: stopped
+    enabled: false
+    masked: true
+```
+
+**Security use case**: Mask services that should never run (cups, avahi-daemon, rpcbind). Masking prevents manual start -- stronger than just disabling.
+
+> **Common Mistakes**
+> - Forgetting `daemon_reload: true` after deploying a new unit file. Without it, systemd doesn't see the change.
+> - Using `ansible.builtin.systemd` on non-systemd hosts. Use `ansible.builtin.service` for cross-platform compatibility.
+
+---
+
+## Package Management
+
+---
+
+### `ansible.builtin.apt`
+
+Manage packages on Debian/Ubuntu systems.
+
+**First used**: Mission 1.3 -- Clean Sweep
+
+```yaml
+- name: Install security packages
+  ansible.builtin.apt:
+    name:
+      - ufw
+      - fail2ban
+      - unattended-upgrades
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+```
+
+**Security use case**: Ensure security tooling is installed across all Debian-family ships. Remove known-vulnerable or unnecessary packages with `state: absent`.
+
+> **Common Mistakes**
+> - Omitting `update_cache: true` on a fresh system. The package index may be empty, causing failures.
+> - Running `update_cache` on every task without `cache_valid_time`. This hammers mirrors and slows runs. Set `cache_valid_time: 3600` (seconds) to cache for one hour.
+> - Using `apt` on a RHEL host. Use `ansible.builtin.package` or conditionals for multi-OS playbooks.
+
+---
+
+### `ansible.builtin.dnf`
+
+Manage packages on RHEL, Rocky, Fedora, and other dnf-based systems.
+
+**First used**: Mission 1.3 -- Clean Sweep
+
+```yaml
+- name: Install firewalld on Rocky
+  ansible.builtin.dnf:
+    name:
+      - firewalld
+      - audit
+    state: present
+```
+
+**Security use case**: Same as `apt` -- enforce package state on Red Hat-family systems.
+
+> **Common Mistakes**
+> - Using `dnf` on a Debian host. Guard with `when: ansible_os_family == "RedHat"` or use `ansible.builtin.package`.
+> - Forgetting that `dnf` does not have `update_cache` as a standalone param -- it refreshes metadata automatically.
+
+---
+
+### `ansible.builtin.package`
+
+OS-agnostic package management. Delegates to the host's native package manager.
+
+**First used**: Mission 1.4 -- Many Ships
+
+```yaml
+- name: Ensure audit daemon is installed (any OS)
+  ansible.builtin.package:
+    name: audit
+    state: present
+```
+
+**Security use case**: Write a single task that works on both Debian and RHEL fleets. Useful in roles that target heterogeneous environments.
+
+> **Common Mistakes**
+> - Assuming package names are identical across distros. `audit` on RHEL is `auditd` on Debian. Use variables or `ansible_os_family` conditionals for differing names.
+> - Trying to use `apt`-specific params like `update_cache` -- the generic module does not support them.
+
+---
+
+## User Management
+
+---
+
+### `ansible.builtin.user`
+
+Create, modify, or remove user accounts.
+
+**First used**: Mission 1.3 -- Clean Sweep
+
+```yaml
+- name: Create service account with no login shell
+  ansible.builtin.user:
+    name: svc_monitor
+    shell: /usr/sbin/nologin
+    system: true
+    create_home: false
+```
+
+**Security use case**: Provision service accounts with restricted shells. Remove unauthorized accounts. Enforce password expiration with `password_expire_max`.
+
+> **Common Mistakes**
+> - Setting `password` to a plaintext string. The module expects a hashed password. Use `password: "{{ 'secret' | password_hash('sha512') }}"`.
+> - Forgetting `remove: true` with `state: absent`. Without it, the home directory is orphaned.
+
+---
+
+### `ansible.builtin.group`
+
+Create or remove groups.
+
+**First used**: Mission 1.3 -- Clean Sweep
+
+```yaml
+- name: Ensure ops group exists
+  ansible.builtin.group:
+    name: sdc_ops
+    state: present
+```
+
+**Security use case**: Enforce group-based access control. Create groups before assigning users to them via the `user` module's `groups` parameter.
+
+> **Common Mistakes**
+> - Creating a user with `groups: sdc_ops` before the group exists. The `group` task must run first -- use task ordering or role dependencies.
+
+---
+
+## Firewall
+
+---
+
+### `community.general.ufw`
+
+Manage UFW (Uncomplicated Firewall) on Ubuntu/Debian.
+
+**Requires**: `community.general` collection (install via `ansible-galaxy collection install community.general`)
+
+**First used**: Mission 1.3 -- Clean Sweep
+
+```yaml
+- name: Allow SSH and enable UFW
+  community.general.ufw:
+    rule: allow
+    port: "22"
+    proto: tcp
+
+- name: Enable UFW with default deny
+  community.general.ufw:
+    state: enabled
+    default: deny
+    direction: incoming
+```
+
+**Security use case**: Default-deny ingress firewall. Whitelist only required ports (SSH, HTTPS). This is a foundational CIS benchmark control.
+
+> **Common Mistakes**
+> - Enabling UFW *before* allowing SSH. This locks you out instantly. Always allow SSH first, then enable.
+> - Forgetting `proto: tcp`. Without it, both TCP and UDP are affected -- usually not intended.
+> - Not setting `default: deny` for incoming. UFW defaults to allow, which provides no protection.
+
+---
+
+### `ansible.posix.firewalld`
+
+Manage firewalld zones and rules on RHEL/Rocky.
+
+**Requires**: `ansible.posix` collection (install via `ansible-galaxy collection install ansible.posix`)
+
+**First used**: Mission 1.3 -- Clean Sweep
+
+```yaml
+- name: Allow SSH in public zone (permanent)
+  ansible.posix.firewalld:
+    service: ssh
+    zone: public
+    permanent: true
+    immediate: true
+    state: enabled
+```
+
+**Security use case**: Zone-based firewall management. Assign interfaces to zones, control services and ports per zone.
+
+> **Common Mistakes**
+> - Setting `permanent: true` without `immediate: true`. The rule is saved but not active until next reload/reboot.
+> - Confusing `service:` with `port:`. Use `service: ssh` for well-known services, `port: "8443/tcp"` for custom ports.
+
+---
+
+## System Configuration
+
+---
+
+### `ansible.posix.sysctl`
+
+Set kernel parameters via sysctl. This is the correct module to use.
+
+**Requires**: `ansible.posix` collection
+
+**First used**: Mission 2.2 -- Compliance as Code
+
+```yaml
+- name: Disable IP forwarding
+  ansible.posix.sysctl:
+    name: net.ipv4.ip_forward
+    value: "0"
+    sysctl_set: true
+    state: present
+    reload: true
+```
+
+**Security use case**: Kernel hardening -- disable IP forwarding, enable SYN cookies, restrict ICMP redirects, enable ASLR. These are CIS Level 1 benchmark controls.
+
+> **Common Mistakes**
+> - Using `ansible.builtin.sysctl` instead. See deprecation note below.
+> - Forgetting `sysctl_set: true`. Without it, the value is written to the file but not applied to the running kernel.
+> - Not quoting numeric values. Write `value: "0"`, not `value: 0`.
+
+---
+
+### `ansible.builtin.sysctl` (DEPRECATED)
+
+> **WARNING**: This module is deprecated in favor of `ansible.posix.sysctl`. It will be removed in a future Ansible release. Migrate all usage to `ansible.posix.sysctl`. The syntax is identical -- only the FQCN changes.
+
+---
+
+### `ansible.builtin.cron`
+
+Manage cron jobs.
+
+**First used**: Mission 1.3 -- Clean Sweep
+
+```yaml
+- name: Schedule daily security audit
+  ansible.builtin.cron:
+    name: "daily-lynis-scan"
+    hour: "2"
+    minute: "30"
+    job: "/usr/sbin/lynis audit system --quick --quiet >> /var/log/lynis-daily.log 2>&1"
+    user: root
+```
+
+**Security use case**: Schedule recurring security scans, log rotation, or compliance checks. The `name` field makes the job idempotent.
+
+> **Common Mistakes**
+> - Omitting `name`. Without it, Ansible cannot identify the job for updates or removal -- you get duplicates on every run.
+> - Forgetting to redirect output. Cron sends stdout/stderr as mail by default, which fills mailboxes or bounces.
+
+---
+
+## SSH
+
+---
+
+### `ansible.builtin.authorized_key`
+
+Manage SSH authorized keys for user accounts.
+
+**First used**: Mission 1.2 -- Lock the Door
+
+```yaml
+- name: Deploy operator SSH key
+  ansible.builtin.authorized_key:
+    user: sdc_operator
+    key: "{{ lookup('file', 'files/operator_ed25519.pub') }}"
+    state: present
+    exclusive: false
+```
+
+**Security use case**: Centrally manage who can SSH into each ship. Use `exclusive: true` to remove all keys not managed by Ansible -- nuclear option for key hygiene.
+
+> **Common Mistakes**
+> - Setting `exclusive: true` without including ALL authorized keys in your playbook. This removes every key not listed, including your own.
+> - Deploying private keys instead of public keys. The `key:` parameter takes the `.pub` file content.
+> - Forgetting that the user's `~/.ssh/` directory must exist with correct permissions (700). The module creates it, but only if the user exists.
+
+---
+
+## Vault & Secrets
+
+---
+
+### `ansible.builtin.include_vars`
+
+Load variables from a YAML file (including Vault-encrypted files) into the play.
+
+**First used**: Mission 1.5 -- Clean House
+
+```yaml
+- name: Load encrypted credentials
+  ansible.builtin.include_vars:
+    file: vault/credentials.yml
+```
+
+**Security use case**: Separate secrets from playbook logic. The encrypted file stays in version control; the vault password stays out of it.
+
+> **Common Mistakes**
+> - Committing the vault password file to Git. Add it to `.gitignore` immediately.
+> - Referencing `vault_password_file` in `ansible.cfg` before the file exists. This breaks all Ansible commands. Ship the line commented out; have operators uncomment after setup.
+
+---
+
+### `ansible-vault` CLI Reference
+
+Not a module -- a command-line tool for encrypting and decrypting files.
+
+| Command | Purpose |
+|---------|---------|
+| `ansible-vault create secrets.yml` | Create a new encrypted file |
+| `ansible-vault edit secrets.yml` | Decrypt, edit in `$EDITOR`, re-encrypt |
+| `ansible-vault encrypt existing.yml` | Encrypt an existing plaintext file |
+| `ansible-vault decrypt secrets.yml` | Decrypt to plaintext (use sparingly) |
+| `ansible-vault view secrets.yml` | View contents without decrypting to disk |
+| `ansible-vault encrypt_string 'value' --name 'var_name'` | Encrypt a single variable inline |
+| `ansible-vault rekey secrets.yml` | Change the encryption password |
+
+**First used**: Mission 1.5 -- Clean House
+
+**Security use case**: Protect passwords, API keys, and certificates at rest. Vault-encrypted files are safe to commit. The vault password itself must be managed separately (password manager, CI/CD secret, or secure file).
+
+> **Common Mistakes**
+> - Encrypting entire playbooks instead of just the variable files. Encrypt the smallest scope possible.
+> - Using `ansible-vault decrypt` and forgetting to re-encrypt. The plaintext file ends up committed.
+> - Using a weak vault password. Treat it like any production credential.
+
+---
+
+## Orchestration (Module 2)
+
+---
+
+### `ansible.builtin.wait_for`
+
+Wait for a condition before proceeding -- port open, file exists, or line appears in a log.
+
+**First used**: Mission 2.3 -- Fleet Sync
+
+```yaml
+- name: Wait for application port to accept connections
+  ansible.builtin.wait_for:
+    port: 8443
+    host: "{{ inventory_hostname }}"
+    delay: 5
+    timeout: 60
+```
+
+**Security use case**: Rolling updates -- confirm each ship's service is healthy before proceeding to the next. Prevents fleet-wide outages from bad deployments.
+
+> **Common Mistakes**
+> - Setting `timeout` too low. Network latency or slow services cause false failures.
+> - Forgetting `delay` for services that need startup time. Without it, the check starts immediately and may hit a false positive on a lingering old process.
+
+---
+
+### `ansible.builtin.fail`
+
+Abort the play with a custom message. Use for guardrails.
+
+**First used**: Mission 2.3 -- Fleet Sync
+
+```yaml
+- name: Abort if free disk space is critically low
+  ansible.builtin.fail:
+    msg: "ABORT: {{ inventory_hostname }} has only {{ free_space_mb }}MB free"
+  when: free_space_mb | int < 500
+```
+
+**Security use case**: Pre-flight safety checks. Halt deployment if conditions are unsafe -- disk full, wrong OS version, missing prerequisites.
+
+> **Common Mistakes**
+> - Using `fail` without `when`. This unconditionally aborts the play every time.
+
+---
+
+### `ansible.builtin.assert`
+
+Validate conditions and fail with a descriptive message if they are not met.
+
+**First used**: Mission 2.3 -- Fleet Sync
+
+```yaml
+- name: Validate minimum Ansible version
+  ansible.builtin.assert:
+    that:
+      - ansible_version.full is version('2.14', '>=')
+      - ansible_os_family in ['Debian', 'RedHat']
+    fail_msg: "Unsupported platform or Ansible version"
+    success_msg: "Pre-flight checks passed"
+```
+
+**Security use case**: Enforce preconditions before running hardening playbooks. Verify OS family, kernel version, or required variables are defined.
+
+> **Common Mistakes**
+> - Using Python comparison operators (`==`, `!=`) instead of Jinja2 tests (`is version`, `is defined`).
+> - Putting complex logic in `that:` instead of computing it in a prior task and asserting on the registered result.
+
+---
+
+### `ansible.builtin.debug`
+
+Print variables or messages during execution. Essential for troubleshooting.
+
+**First used**: Mission 1.1 -- Fleet Census (ad-hoc)
+
+```yaml
+- name: Show gathered network facts
+  ansible.builtin.debug:
+    var: ansible_default_ipv4.address
+    verbosity: 1
+```
+
+**Security use case**: Verify variable values during development. Use `verbosity: 1` or higher to hide output in normal runs -- prevents leaking sensitive data in CI logs.
+
+> **Common Mistakes**
+> - Leaving `debug` tasks with `verbosity: 0` (default) in production playbooks. They clutter output and may expose secrets.
+> - Using `msg:` and `var:` simultaneously. They are mutually exclusive.
+
+---
+
+### `ansible.builtin.shell`
+
+Execute commands through the host's shell (`/bin/sh`). Supports pipes, redirects, and environment variables.
+
+**First used**: Mission 1.1 -- Fleet Census (ad-hoc)
+
+```yaml
+- name: Check for unauthorized SUID binaries
+  ansible.builtin.shell: >
+    find / -perm -4000 -type f 2>/dev/null
+  register: suid_binaries
+  changed_when: false
+```
+
+> **SECURITY WARNING**: The `shell` module is powerful and dangerous. It is not idempotent by default. Prefer purpose-built modules (`file`, `copy`, `user`, etc.) whenever possible. If you must use `shell`:
+> - Always set `changed_when` to control idempotency.
+> - Never pass untrusted variables directly into the command string (injection risk).
+> - Use `creates:` or `removes:` to make it idempotent where applicable.
+> - `ansible-lint` will flag shell usage -- acknowledge it only when no module alternative exists.
+
+> **Common Mistakes**
+> - Using `shell` to install packages instead of `apt`/`dnf`. Modules handle idempotency; shell does not.
+> - Forgetting `changed_when: false` for read-only commands. Without it, Ansible reports "changed" every run.
+
+---
+
+### `ansible.builtin.command`
+
+Execute a command directly (no shell). Safer than `shell` -- no pipes, redirects, or variable expansion.
+
+**First used**: Mission 1.1 -- Fleet Census (ad-hoc)
+
+```yaml
+- name: Check SSH daemon version
+  ansible.builtin.command:
+    cmd: sshd -V
+  register: sshd_version
+  changed_when: false
+```
+
+**Security use case**: Preferred over `shell` when you do not need shell features. Eliminates shell injection risk. Use for running binaries with fixed arguments.
+
+> **Common Mistakes**
+> - Using `command` when you need pipes or redirects. It will fail silently or error. Use `shell` for those cases.
+> - Same idempotency issue as `shell` -- always set `changed_when` or use `creates:`/`removes:`.
+
+---
+
+## Cross-Reference: Module by Mission
+
+| Mission | Key Modules Introduced |
+|---------|----------------------|
+| **1.1** Fleet Census | `command`, `shell`, `debug`, `ping` (ad-hoc) |
+| **1.2** Lock the Door | `lineinfile`, `service`, `authorized_key`, handlers |
+| **1.3** Clean Sweep | `apt`, `dnf`, `ufw`, `firewalld`, `copy`, `file`, `user`, `group`, `systemd`, `cron`, `stat` |
+| **1.4** Many Ships | `template`, `package`, `group_vars` (not a module -- a pattern) |
+| **1.5** Clean House | `include_vars`, `ansible-vault` CLI |
+| **2.1** Weapon Handling Test | Molecule/Testinfra (no new Ansible modules) |
+| **2.2** Compliance as Code | `ansible.posix.sysctl`, `copy` (limits.d), `lineinfile` (sshd_config hardening) |
+| **2.3** Fleet Sync | `wait_for`, `fail`, `assert`, `delegate_to`, `serial` |
+| **2.4** Defence in Depth | `ansible-lint` (not a module -- a CI tool) |
+
+---
+
+## Collection Installation Reference
+
+Several modules require collections that are not bundled with `ansible-core`. Install them before use.
+
+```bash
+# Install required collections
+ansible-galaxy collection install community.general
+ansible-galaxy collection install ansible.posix
+
+# Or use a requirements.yml
+cat > collections/requirements.yml << 'EOF'
+collections:
+  - name: community.general
+  - name: ansible.posix
+EOF
+ansible-galaxy collection install -r collections/requirements.yml
+```
+
+> All SDC Academy missions handle collection installation automatically via `make setup`. This reference is for operators working outside the training environment.
+
+---
+
+*Filed under: SDC Academy Training Command // FM-1 Rev 1.0*
+*This field manual is maintained in the sdc-academy repository. Report errors via issue tracker.*

--- a/field-manuals/FM-2-yaml-jinja2-reference.md
+++ b/field-manuals/FM-2-yaml-jinja2-reference.md
@@ -1,0 +1,638 @@
+# FM-2: YAML & Jinja2 Quick Reference
+> Starfall Defence Corps — Field Manual
+
+YAML is the language you write Ansible in. Jinja2 is the template engine that makes it dynamic. Master both or your playbooks will break in ways the error messages will not explain.
+
+This manual is a reference, not a tutorial. If you need the walkthrough, start with [Mission 1.2: Lock the Door](https://github.com/starfall-defence-corps/mission-1-2-lock-the-door) for YAML structure and [Mission 1.4: Many Ships](https://github.com/starfall-defence-corps/mission-1-4-many-ships) for Jinja2 templating.
+
+---
+
+## Part 1: YAML
+
+YAML (YAML Ain't Markup Language) is a data serialisation format. Every Ansible playbook, inventory file, and variable file is YAML. Get the fundamentals right here and you will avoid hours of debugging indentation errors in the field.
+
+### Data Types
+
+```yaml
+# Strings
+ship_name: Artemis
+ship_class: "Vanguard-II"       # Quotes optional unless value contains special chars
+
+# Integers
+hull_strength: 9500
+deck_count: 12
+
+# Floats
+shield_efficiency: 0.97
+
+# Booleans
+weapons_online: true
+stealth_mode: false
+
+# Null
+last_breach_date: null           # Also accepted: ~
+cargo_manifest:                  # Empty value is also null
+```
+
+> **First encountered**: Mission 1.1 — your fleet inventory file uses all of these.
+
+### Lists
+
+Block style (one item per line):
+
+```yaml
+active_vessels:
+  - Artemis
+  - Constellation
+  - Vigilant
+```
+
+Flow style (inline):
+
+```yaml
+active_vessels: [Artemis, Constellation, Vigilant]
+```
+
+List of dictionaries (the most common pattern in playbooks):
+
+```yaml
+tasks:
+  - name: Harden SSH configuration
+    ansible.builtin.template:
+      src: sshd_config.j2
+      dest: /etc/ssh/sshd_config
+
+  - name: Restart SSH daemon
+    ansible.builtin.service:
+      name: sshd
+      state: restarted
+```
+
+> **First encountered**: Mission 1.2 — your first playbook is a list of tasks.
+
+### Dictionaries
+
+Block style:
+
+```yaml
+ship_specs:
+  name: Artemis
+  class: Vanguard-II
+  crew: 340
+  weapons_online: true
+```
+
+Flow style:
+
+```yaml
+ship_specs: {name: Artemis, class: Vanguard-II, crew: 340}
+```
+
+Nested dictionaries:
+
+```yaml
+fleet:
+  sector_7:
+    flagship: Artemis
+    escorts:
+      - Vigilant
+      - Iron Resolve
+  sector_12:
+    flagship: Constellation
+    escorts:
+      - Stalwart
+```
+
+### Multiline Strings
+
+Literal block (`|`) — preserves newlines exactly:
+
+```yaml
+motd_banner: |
+  ==========================================
+  STARFALL DEFENCE CORPS — CLASSIFIED SYSTEM
+  Unauthorised access will be prosecuted.
+  ==========================================
+```
+
+Folded block (`>`) — folds newlines into spaces (becomes one paragraph):
+
+```yaml
+ship_description: >
+  The Artemis is a Vanguard-class cruiser
+  assigned to Sector 7 patrol. She carries
+  a crew of 340 and full weapons complement.
+```
+
+Strip modifier (`-`) — removes the trailing newline:
+
+```yaml
+# With trailing newline (default)
+banner: |
+  Line one
+  Line two
+
+# Without trailing newline
+banner: |-
+  Line one
+  Line two
+```
+
+| Indicator | Newlines      | Trailing newline |
+|-----------|---------------|------------------|
+| `\|`      | Preserved     | Yes              |
+| `\|-`     | Preserved     | No               |
+| `\|+`     | Preserved     | All kept         |
+| `>`       | Folded        | Yes              |
+| `>-`      | Folded        | No               |
+| `>+`      | Folded        | All kept         |
+
+> **First encountered**: Mission 1.2 — SSH banners use literal blocks. Mission 1.4 — templates use both styles.
+
+### Boolean Coercion Gotcha
+
+YAML 1.1 (used by PyYAML, which Ansible uses) treats all of these as booleans:
+
+```yaml
+# All of these become True
+enabled: yes
+enabled: Yes
+enabled: YES
+enabled: true
+enabled: True
+enabled: on
+
+# All of these become False
+enabled: no
+enabled: No
+enabled: false
+enabled: off
+```
+
+If you mean the **string** `"yes"`, you must quote it:
+
+```yaml
+survey_response: "yes"          # String "yes"
+survey_response: yes            # Boolean true — not what you wanted
+```
+
+YAML 1.2 removed `yes`/`no`/`on`/`off` as booleans, but Ansible still uses YAML 1.1 under the hood. Know this. It will bite you.
+
+### Anchors and Aliases
+
+Define a value once with `&`, reuse it with `*`:
+
+```yaml
+defaults: &security_defaults
+  ssh_port: 2222
+  permit_root: false
+  max_auth_tries: 3
+
+web_server:
+  <<: *security_defaults
+  role: web
+
+db_server:
+  <<: *security_defaults
+  role: database
+  ssh_port: 2223              # Override one value
+```
+
+The `<<` merge key inserts all key-value pairs from the anchor. Individual keys can be overridden after the merge. Useful for DRY variable files, but use sparingly — deeply nested merges become hard to debug.
+
+### Comments
+
+```yaml
+# Full line comment
+ship_name: Artemis   # Inline comment
+```
+
+YAML comments are not preserved by most parsers. Ansible will never see them. Use them for human readers.
+
+### Quoting Rules — When You MUST Quote
+
+| Situation | Example | Why |
+|-----------|---------|-----|
+| Value starts with `{` or `[` | `"{{ variable }}"` | YAML sees a flow mapping/sequence |
+| Value contains `: ` (colon-space) | `"http://fleet:8080"` | YAML sees a key-value pair |
+| Value is a YAML boolean word | `"yes"`, `"no"`, `"true"` | Parsed as boolean otherwise |
+| Value is a number but you want a string | `"0700"`, `"3.0"` | Parsed as int/float otherwise |
+| Value contains `#` | `"C# hardening"` | YAML sees a comment |
+| Value starts with `*`, `&`, `!`, `%`, `@`, `` ` `` | `"*priority"` | Reserved YAML indicators |
+| Empty string | `""` | Bare empty is null, not empty string |
+
+When in doubt, quote it. Double quotes allow escape sequences (`\n`, `\t`). Single quotes are literal (no escapes). Either works for the cases above.
+
+---
+
+## Part 2: Jinja2 in Ansible
+
+Jinja2 is the template engine Ansible uses for dynamic content. It appears in two places: template files (`.j2`) and inline within playbook YAML. The syntax is the same in both, but the rules around quoting differ.
+
+### Variable Substitution
+
+```yaml
+# In a playbook
+- name: Set hostname
+  ansible.builtin.hostname:
+    name: "{{ inventory_hostname }}"
+
+# In a template (.j2 file)
+Hostname: {{ inventory_hostname }}
+Sector: {{ sector_assignment }}
+```
+
+Variables come from: inventory, `group_vars/`, `host_vars/`, `vars:` sections, registered results, and Ansible facts.
+
+```yaml
+# Accessing nested values
+network_ip: "{{ ansible_default_ipv4.address }}"
+
+# Accessing list items
+first_dns: "{{ dns_servers[0] }}"
+```
+
+> **First encountered**: Mission 1.4 — variables and templates are the core objective.
+
+### Filters
+
+Filters transform data. Syntax: `{{ value | filter }}`. You can chain them: `{{ value | filter1 | filter2 }}`.
+
+**String filters**:
+
+```yaml
+# Case manipulation
+hostname_lower: "{{ ship_name | lower }}"          # artemis
+hostname_upper: "{{ ship_name | upper }}"          # ARTEMIS
+
+# Search and replace
+clean_name: "{{ raw_input | replace(' ', '_') }}"
+sanitised: "{{ log_line | regex_replace('[0-9]+', 'X') }}"
+```
+
+**Default values** — critical for defensive coding:
+
+```yaml
+# Use default if variable is undefined
+ssh_port: "{{ custom_ssh_port | default(22) }}"
+
+# Use default if variable is undefined OR empty
+ssh_port: "{{ custom_ssh_port | default(22, true) }}"
+```
+
+**Data structure filters**:
+
+```yaml
+# Convert dict to list of {key, value} pairs
+- name: Apply sysctl settings
+  ansible.posix.sysctl:
+    name: "{{ item.key }}"
+    value: "{{ item.value }}"
+  loop: "{{ sysctl_settings | dict2items }}"
+
+# Merge two dictionaries
+combined: "{{ defaults | combine(overrides) }}"
+
+# Deep merge (recursive)
+combined: "{{ defaults | combine(overrides, recursive=True) }}"
+```
+
+> **`dict2items` first encountered**: Mission 2.2 — iterating over CIS benchmark settings.
+
+**Serialisation filters**:
+
+```yaml
+# Convert to YAML or JSON (useful in templates)
+config_block: "{{ settings | to_yaml }}"
+api_payload: "{{ data | to_json }}"
+human_readable: "{{ data | to_nice_yaml }}"
+```
+
+**Other commonly used filters**:
+
+```yaml
+# List operations
+unique_hosts: "{{ all_hosts | unique }}"
+sorted_ships: "{{ fleet | sort(attribute='name') }}"
+web_only: "{{ fleet | selectattr('role', 'eq', 'web') | list }}"
+
+# Math
+max_value: "{{ scores | max }}"
+total: "{{ values | sum }}"
+
+# Type casting
+port_number: "{{ ssh_port | int }}"
+enabled: "{{ flag | bool }}"
+
+# Path manipulation
+filename: "{{ filepath | basename }}"
+directory: "{{ filepath | dirname }}"
+```
+
+### Conditionals
+
+**In templates** (`.j2` files):
+
+```jinja
+{% if weapons_online %}
+ALERT: Weapons systems are HOT.
+{% elif maintenance_mode %}
+NOTE: Ship is in maintenance cycle.
+{% else %}
+STATUS: Standard patrol configuration.
+{% endif %}
+```
+
+**In playbooks** (`when:` clause):
+
+```yaml
+- name: Install firewalld on RHEL-based systems
+  ansible.builtin.dnf:
+    name: firewalld
+    state: present
+  when: ansible_os_family == "RedHat"
+
+# Multiple conditions
+- name: Apply hardening only on production web servers
+  ansible.builtin.include_role:
+    name: cis_hardening
+  when:
+    - environment == "production"
+    - "'web' in group_names"
+
+# Boolean checks
+- name: Restart if config changed
+  ansible.builtin.service:
+    name: sshd
+    state: restarted
+  when: sshd_config.changed
+```
+
+> **First encountered**: Mission 1.4 — conditionals handle multi-OS playbooks.
+
+### Loops
+
+**In templates**:
+
+```jinja
+{% for ship in fleet_roster %}
+{{ ship.name }} — {{ ship.class }} — Sector {{ ship.sector }}
+{% endfor %}
+```
+
+**In playbooks** (modern `loop:`):
+
+```yaml
+- name: Create fleet user accounts
+  ansible.builtin.user:
+    name: "{{ item }}"
+    groups: defence_corps
+    state: present
+  loop:
+    - cadet_reeves
+    - cadet_okafor
+    - lt_vasquez
+```
+
+**Looping over dictionaries**:
+
+```yaml
+- name: Apply sysctl hardening
+  ansible.posix.sysctl:
+    name: "{{ item.key }}"
+    value: "{{ item.value }}"
+    sysctl_set: true
+    reload: true
+  loop: "{{ sysctl_params | dict2items }}"
+```
+
+**Loop with index**:
+
+```jinja
+{% for port in open_ports %}
+Rule {{ loop.index }}: ALLOW {{ port }}/tcp
+{% endfor %}
+```
+
+The legacy `with_items:` still works but `loop:` is the current standard.
+
+### Whitespace Control
+
+In templates, Jinja2 tags can introduce unwanted blank lines. Use the strip modifier (`-`) to consume whitespace:
+
+```jinja
+{# Without whitespace control — leaves blank lines #}
+{% if enable_banner %}
+{{ banner_text }}
+{% endif %}
+
+{# With whitespace control — clean output #}
+{%- if enable_banner %}
+{{ banner_text }}
+{%- endif %}
+```
+
+| Syntax | Effect |
+|--------|--------|
+| `{% ... %}` | Normal — whitespace preserved |
+| `{%- ... %}` | Strip whitespace before the tag |
+| `{% ... -%}` | Strip whitespace after the tag |
+| `{%- ... -%}` | Strip both sides |
+| `{{- var -}}` | Same rules apply to variable tags |
+
+Use whitespace control in templates that generate config files. Extra blank lines in `/etc/ssh/sshd_config` are harmless but sloppy. Extra blank lines in a cron file can break things.
+
+### Undefined Variables and `default()`
+
+Ansible fails hard on undefined variables by default. The `default()` filter is your safety net:
+
+```yaml
+# Provide a fallback
+max_retries: "{{ custom_retries | default(3) }}"
+
+# Provide fallback even for empty strings and false
+always_set: "{{ maybe_empty | default('none', true) }}"
+
+# Omit the parameter entirely if undefined
+- name: Create user
+  ansible.builtin.user:
+    name: "{{ username }}"
+    shell: "{{ custom_shell | default(omit) }}"
+```
+
+The `omit` special value tells Ansible to skip the parameter entirely, as if you never wrote it. This is different from passing an empty string or null.
+
+### The Quoting Gotcha
+
+When a YAML value **starts with** `{{`, the YAML parser sees `{` and thinks it is a flow mapping. You must quote:
+
+```yaml
+# BROKEN — YAML parser error
+hostname: {{ inventory_hostname }}
+
+# CORRECT
+hostname: "{{ inventory_hostname }}"
+```
+
+In Jinja2 template files (`.j2`), you do NOT need quotes — the file is processed as a template, not as YAML:
+
+```jinja
+Hostname: {{ inventory_hostname }}
+```
+
+Rule of thumb: **In YAML files, always quote Jinja2 expressions.** In `.j2` files, never quote them (unless you want literal quote characters in the output).
+
+---
+
+## Part 3: Common Gotchas
+
+These are the errors that waste the most cadet time across all missions. Learn them here or learn them the hard way in a timed simulation.
+
+### Indentation: 2 Spaces, Never Tabs
+
+YAML uses spaces for indentation. Tabs are illegal. The Ansible standard is 2 spaces per level.
+
+```yaml
+# CORRECT — 2 spaces
+- hosts: all
+  tasks:
+    - name: Install package
+      ansible.builtin.apt:
+        name: nginx
+        state: present
+
+# BROKEN — mixed or wrong indentation
+- hosts: all
+  tasks:
+  - name: Install package     # Wrong: task should be indented under tasks
+      ansible.builtin.apt:
+          name: nginx          # Wrong: 4 extra spaces
+```
+
+Configure your editor to insert spaces when you press Tab, and set the indent width to 2. Do this before Mission 1.2 or you will fight your editor the entire time.
+
+### The "Colon Space" Trap
+
+YAML interprets `key: value` as a dictionary entry. If your string contains `: ` (colon followed by a space), YAML will split it:
+
+```yaml
+# BROKEN — YAML sees "http" as a key
+url: http://fleet-command:8080/api
+
+# CORRECT — quoted
+url: "http://fleet-command:8080/api"
+
+# Also safe — no space after colon (but don't rely on this)
+url: http://fleet-command:8080/api   # Only works because port has no space after
+```
+
+The trigger is specifically colon followed by a space. `key:value` without a space is a string. But do not rely on this — quote anything with a colon to be safe.
+
+### Boolean Values: `yes` Is Not a String
+
+```yaml
+# This becomes boolean true, not the string "yes"
+answer: yes
+
+# These are strings
+answer: "yes"
+answer: 'yes'
+```
+
+This bites hardest in inventory files and variable files. If a downstream template or conditional expects a string, passing a boolean will produce unexpected behaviour. When you want a string, quote it.
+
+### Empty Values: `null` vs `""` vs Omitted
+
+```yaml
+key:              # null (key exists, value is null)
+key: null         # null (explicit)
+key: ~            # null (tilde shorthand)
+key: ""           # Empty string (key exists, value is "")
+# key omitted     # Key does not exist at all
+```
+
+These are four different states. They behave differently in conditionals:
+
+```yaml
+# Given: my_var is null
+when: my_var                    # False (null is falsy)
+when: my_var is defined         # True (it exists)
+when: my_var is not none        # False (it is none)
+
+# Given: my_var is ""
+when: my_var                    # False (empty string is falsy)
+when: my_var is defined         # True
+when: my_var | length > 0       # False
+```
+
+### Jinja2 in `when:` — No Double Braces
+
+The `when:` clause is already evaluated as a Jinja2 expression. Adding `{{ }}` wraps it in a string, which is almost never what you want:
+
+```yaml
+# WRONG — this evaluates the variable, converts to string, then tests truthiness
+- name: Check OS
+  ansible.builtin.debug:
+    msg: "RedHat detected"
+  when: "{{ ansible_os_family == 'RedHat' }}"
+
+# CORRECT — bare expression
+- name: Check OS
+  ansible.builtin.debug:
+    msg: "RedHat detected"
+  when: ansible_os_family == "RedHat"
+```
+
+Ansible will warn you about this with a deprecation notice, but the warning is easy to miss in dense output. Get the habit right now: **`when:` clauses never use `{{ }}`**.
+
+### Template Whitespace: Extra Newlines in Rendered Files
+
+When your template has Jinja2 blocks, each `{% %}` tag produces a blank line in the output:
+
+```jinja
+# Input template
+{% for rule in firewall_rules %}
+{{ rule }}
+{% endfor %}
+
+# Output (3 rules) — note the extra blank lines
+rule1
+
+rule2
+
+rule3
+```
+
+Fix with whitespace stripping:
+
+```jinja
+{% for rule in firewall_rules -%}
+{{ rule }}
+{% endfor -%}
+```
+
+Or use `#jinja2: trim_blocks:True, lstrip_blocks:True` at the top of your template to enable automatic stripping.
+
+> **First encountered**: Mission 1.4 — templates that generate config files must have clean output.
+
+---
+
+## Quick Reference Card
+
+| What | Syntax | Example |
+|------|--------|---------|
+| Variable | `{{ }}` | `{{ ssh_port }}` |
+| Statement | `{% %}` | `{% if enabled %}` |
+| Comment | `{# #}` | `{# TODO: remove #}` |
+| Filter | `\|` | `{{ name \| upper }}` |
+| Default | `default()` | `{{ x \| default(22) }}` |
+| Loop var | `loop.index` | First iteration = 1 |
+| Loop var | `loop.index0` | First iteration = 0 |
+| Loop var | `loop.first` | `true` on first iteration |
+| Loop var | `loop.last` | `true` on last iteration |
+| Omit param | `omit` | `{{ x \| default(omit) }}` |
+| Ternary | `ternary()` | `{{ test \| ternary('yes','no') }}` |
+
+---
+
+*FM-2 — Starfall Defence Corps Academy. Know your data formats. The Voidborn won't wait while you debug a missing quote.*

--- a/field-manuals/FM-3-molecule-testing-reference.md
+++ b/field-manuals/FM-3-molecule-testing-reference.md
@@ -1,0 +1,529 @@
+# FM-3: Molecule & Testing Reference
+> Starfall Defence Corps — Field Manual
+
+---
+
+You do not deploy what you have not tested. Molecule and Testinfra are the weapons that prove your infrastructure code works before it touches production. This manual covers the full testing lifecycle.
+
+---
+
+## Molecule Lifecycle
+
+Molecule manages the test cycle for Ansible roles. Each command maps to a phase.
+
+| Command | Purpose |
+|---------|---------|
+| `molecule create` | Spin up test instances (Docker containers, typically) |
+| `molecule converge` | Run the playbook against those instances |
+| `molecule verify` | Execute Testinfra assertions against the converged state |
+| `molecule destroy` | Tear down all test instances |
+| `molecule test` | Full cycle: create, converge, verify, destroy |
+| `molecule login` | SSH into a running instance for manual inspection |
+
+### Full Cycle Breakdown
+
+`molecule test` runs this sequence:
+
+```
+dependency → cleanup → destroy → syntax → create → prepare → converge → idempotence → verify → cleanup → destroy
+```
+
+During development, run individual phases to iterate faster:
+
+```bash
+# Stand up instances once
+molecule create
+
+# Iterate on your role
+molecule converge
+
+# Iterate on your tests
+molecule verify
+
+# Tear down when finished
+molecule destroy
+```
+
+### Targeting a Specific Scenario
+
+```bash
+molecule test -s <scenario-name>
+molecule converge -s hardening
+```
+
+The default scenario lives in `molecule/default/`. Additional scenarios each get their own subdirectory.
+
+---
+
+## molecule.yml Configuration
+
+The scenario configuration file. Every section controls a phase.
+
+### dependency
+
+Install collections or roles before converge.
+
+```yaml
+dependency:
+  name: galaxy
+  options:
+    requirements-file: requirements.yml
+```
+
+### driver
+
+Which backend creates instances. Docker is standard for SDC missions.
+
+```yaml
+driver:
+  name: docker
+```
+
+Other drivers: `default` (pre-existing hosts), `delegated` (you manage creation yourself).
+
+### platforms
+
+Define the test instances. Each entry becomes a container.
+
+```yaml
+platforms:
+  - name: web-01
+    image: geerlingguy/docker-ubuntu2204-ansible
+    pre_build_image: true
+    command: ""
+    published_ports:
+      - "0.0.0.0:2221:22/tcp"
+    groups:
+      - webservers
+      - fleet
+
+  - name: db-01
+    image: geerlingguy/docker-rockylinux9-ansible
+    pre_build_image: true
+    command: ""
+    published_ports:
+      - "0.0.0.0:2222:22/tcp"
+    groups:
+      - databases
+      - fleet
+```
+
+Key fields:
+- **name** — hostname inside the scenario
+- **image** — Docker image (use `geerlingguy` images for systemd support)
+- **pre_build_image** — `true` skips Dockerfile build, uses image as-is
+- **command** — set to `""` for systemd-enabled images
+- **published_ports** — SSH port mapping for Testinfra connections
+- **groups** — Ansible inventory groups this host belongs to
+
+### provisioner
+
+Controls how Ansible runs during converge.
+
+```yaml
+provisioner:
+  name: ansible
+  inventory:
+    links:
+      hosts: ../../workspace/inventory/hosts.ini
+      group_vars: ../../workspace/inventory/group_vars/
+      host_vars: ../../workspace/inventory/host_vars/
+  config_options:
+    defaults:
+      remote_user: root
+```
+
+Use `inventory.links` to point Molecule at the student's real inventory files.
+
+### verifier
+
+Which tool runs assertions.
+
+```yaml
+verifier:
+  name: testinfra
+```
+
+Testinfra is the SDC standard. The alternative is `ansible` (uses assert tasks), but Testinfra gives you Python's full assertion power.
+
+---
+
+## Testinfra Assertions
+
+Testinfra uses a `host` fixture injected into every test function. Each property returns an object with attributes you assert against.
+
+### host.file(path)
+
+Inspect files and directories.
+
+```python
+def test_sshd_config(host):
+    f = host.file("/etc/ssh/sshd_config")
+    assert f.exists
+    assert f.is_file
+    assert f.user == "root"
+    assert f.group == "root"
+    assert f.mode == 0o600
+    assert f.contains("PermitRootLogin no")
+```
+
+| Attribute | Returns |
+|-----------|---------|
+| `.exists` | `True` if path exists |
+| `.is_file` | `True` if regular file |
+| `.is_directory` | `True` if directory |
+| `.mode` | Octal permissions (e.g. `0o755`) |
+| `.user` | Owner username |
+| `.group` | Group name |
+| `.contains(string)` | `True` if file contains the string |
+| `.content_string` | Full file contents as string |
+
+### host.service(name)
+
+Check systemd service state.
+
+```python
+def test_sshd_running(host):
+    svc = host.service("sshd")
+    assert svc.is_running
+    assert svc.is_enabled
+```
+
+| Attribute | Returns |
+|-----------|---------|
+| `.is_running` | `True` if active |
+| `.is_enabled` | `True` if enabled at boot |
+
+### host.package(name)
+
+Verify package installation.
+
+```python
+def test_fail2ban_installed(host):
+    pkg = host.package("fail2ban")
+    assert pkg.is_installed
+```
+
+| Attribute | Returns |
+|-----------|---------|
+| `.is_installed` | `True` if package present |
+| `.version` | Installed version string |
+
+### host.socket(spec)
+
+Check listening ports. The spec format is `tcp://address:port`.
+
+```python
+def test_ssh_listening(host):
+    assert host.socket("tcp://0.0.0.0:22").is_listening
+
+def test_http_listening(host):
+    assert host.socket("tcp://0.0.0.0:80").is_listening
+```
+
+| Attribute | Returns |
+|-----------|---------|
+| `.is_listening` | `True` if socket is bound |
+
+### host.user(name)
+
+Inspect system users.
+
+```python
+def test_deploy_user(host):
+    u = host.user("deploy")
+    assert u.exists
+    assert u.shell == "/bin/bash"
+    assert u.home == "/home/deploy"
+    assert "sudo" in u.groups
+```
+
+| Attribute | Returns |
+|-----------|---------|
+| `.exists` | `True` if user exists |
+| `.uid` | Numeric user ID |
+| `.gid` | Numeric primary group ID |
+| `.groups` | List of group names |
+| `.home` | Home directory path |
+| `.shell` | Login shell path |
+
+### host.group(name)
+
+Inspect system groups.
+
+```python
+def test_ops_group(host):
+    g = host.group("ops")
+    assert g.exists
+```
+
+| Attribute | Returns |
+|-----------|---------|
+| `.exists` | `True` if group exists |
+| `.gid` | Numeric group ID |
+
+### host.process
+
+Query running processes.
+
+```python
+def test_nginx_process(host):
+    procs = host.process.filter(comm="nginx")
+    assert len(procs) > 0
+```
+
+| Method | Returns |
+|--------|---------|
+| `.filter(comm=..., user=...)` | List of matching processes |
+| `.get(comm=...)` | Single process (raises if not exactly one) |
+
+### host.command(cmd)
+
+Run arbitrary commands and inspect output.
+
+```python
+def test_ansible_version(host):
+    cmd = host.command("ansible --version")
+    assert cmd.rc == 0
+    assert "core 2" in cmd.stdout
+
+def test_no_world_writable(host):
+    cmd = host.command("find /etc -perm -002 -type f")
+    assert cmd.stdout.strip() == ""
+```
+
+| Attribute | Returns |
+|-----------|---------|
+| `.rc` | Exit code (0 = success) |
+| `.stdout` | Standard output string |
+| `.stderr` | Standard error string |
+
+### host.system_info
+
+Identify the operating system.
+
+```python
+def test_os_family(host):
+    assert host.system_info.type == "linux"
+    assert host.system_info.distribution in ["ubuntu", "rocky"]
+```
+
+| Attribute | Returns |
+|-----------|---------|
+| `.type` | OS type (`linux`, `freebsd`, etc.) |
+| `.distribution` | Distro name (lowercase) |
+| `.release` | Version string |
+| `.codename` | Release codename (Debian/Ubuntu) |
+
+### host.sysctl(param)
+
+Read kernel parameters directly.
+
+```python
+def test_ip_forwarding_disabled(host):
+    assert host.sysctl("net.ipv4.ip_forward") == 0
+
+def test_syn_cookies(host):
+    assert host.sysctl("net.ipv4.tcp_syncookies") == 1
+```
+
+Returns the parameter value directly (int or string depending on the kernel parameter).
+
+### host.interface(name)
+
+Inspect network interfaces.
+
+```python
+def test_loopback(host):
+    lo = host.interface("lo")
+    assert lo.exists
+    assert "127.0.0.1" in lo.addresses
+```
+
+| Attribute | Returns |
+|-----------|---------|
+| `.exists` | `True` if interface exists |
+| `.addresses` | List of IP addresses |
+
+---
+
+## Multi-Platform Testing
+
+Fleet infrastructure runs multiple OS families. Your tests must handle both.
+
+### SSH Connection with Multiple Hosts
+
+Testinfra connects to Molecule instances via SSH using published ports:
+
+```bash
+pytest --hosts='ssh://root@localhost:2221,ssh://root@localhost:2222' \
+       --ssh-identity-file=../../.ssh/id_rsa \
+       tests/
+```
+
+### Conditional Assertions by OS
+
+Use `host.system_info.distribution` to branch logic when behaviour differs across platforms.
+
+```python
+def test_firewall_service(host):
+    distro = host.system_info.distribution
+    if distro == "ubuntu":
+        assert host.service("ufw").is_enabled
+    elif distro == "rocky":
+        assert host.service("firewalld").is_enabled
+
+def test_ssh_package(host):
+    distro = host.system_info.distribution
+    if distro == "ubuntu":
+        assert host.package("openssh-server").is_installed
+    elif distro == "rocky":
+        assert host.package("openssh-server").is_installed
+```
+
+### Parametrised Tests
+
+Use pytest parametrize for values that differ by OS:
+
+```python
+import pytest
+
+SSH_PACKAGES = {
+    "ubuntu": "openssh-server",
+    "rocky": "openssh-server",
+}
+
+def test_ssh_installed(host):
+    distro = host.system_info.distribution
+    pkg_name = SSH_PACKAGES.get(distro, "openssh-server")
+    assert host.package(pkg_name).is_installed
+```
+
+### conftest.py for Host Selection
+
+Standard pattern used across SDC missions:
+
+```python
+import pytest
+import testinfra
+
+def pytest_addoption(parser):
+    parser.addoption("--hosts", action="store", default=None)
+    parser.addoption("--ssh-identity-file", action="store", default=None)
+
+@pytest.fixture(scope="module", params=hosts)
+def host(request):
+    yield testinfra.get_host(request.param)
+```
+
+---
+
+## Common Patterns
+
+### Testing SSH Configuration
+
+```python
+def test_sshd_hardened(host):
+    cfg = host.file("/etc/ssh/sshd_config")
+    assert cfg.exists
+    assert cfg.contains("PermitRootLogin no")
+    assert cfg.contains("PasswordAuthentication no")
+    assert cfg.contains("MaxAuthTries 3")
+    assert host.service("sshd").is_running
+    assert host.socket("tcp://0.0.0.0:22").is_listening
+```
+
+### Testing Firewall Rules
+
+```python
+def test_ufw_active(host):
+    """Ubuntu firewall."""
+    cmd = host.command("ufw status")
+    assert "Status: active" in cmd.stdout
+    assert "22/tcp" in cmd.stdout
+
+def test_firewalld_active(host):
+    """Rocky/RHEL firewall."""
+    assert host.service("firewalld").is_running
+    cmd = host.command("firewall-cmd --list-services")
+    assert "ssh" in cmd.stdout
+```
+
+### Testing File Permissions
+
+```python
+def test_sensitive_files(host):
+    for path, expected_mode in [
+        ("/etc/shadow", 0o640),
+        ("/etc/gshadow", 0o640),
+        ("/etc/passwd", 0o644),
+    ]:
+        f = host.file(path)
+        assert f.exists
+        assert f.mode == expected_mode, f"{path} mode {oct(f.mode)} != {oct(expected_mode)}"
+```
+
+### Testing Service State
+
+```python
+REQUIRED_SERVICES = ["sshd", "rsyslog", "cron"]
+BANNED_SERVICES = ["telnet", "rsh"]
+
+def test_required_running(host):
+    for name in REQUIRED_SERVICES:
+        svc = host.service(name)
+        assert svc.is_running, f"{name} not running"
+        assert svc.is_enabled, f"{name} not enabled"
+
+def test_banned_stopped(host):
+    for name in BANNED_SERVICES:
+        svc = host.service(name)
+        assert not svc.is_running, f"{name} should not be running"
+```
+
+### Testing Package Presence / Absence
+
+```python
+REQUIRED_PACKAGES = ["fail2ban", "auditd", "unattended-upgrades"]
+BANNED_PACKAGES = ["telnetd", "rsh-server"]
+
+def test_required_installed(host):
+    for name in REQUIRED_PACKAGES:
+        assert host.package(name).is_installed, f"{name} not installed"
+
+def test_banned_removed(host):
+    for name in BANNED_PACKAGES:
+        assert not host.package(name).is_installed, f"{name} should be removed"
+```
+
+### Testing Sysctl Values
+
+```python
+HARDENED_SYSCTLS = {
+    "net.ipv4.ip_forward": 0,
+    "net.ipv4.tcp_syncookies": 1,
+    "net.ipv4.conf.all.accept_redirects": 0,
+    "net.ipv4.conf.all.send_redirects": 0,
+    "net.ipv6.conf.all.accept_redirects": 0,
+}
+
+def test_sysctl_hardened(host):
+    for param, expected in HARDENED_SYSCTLS.items():
+        actual = host.sysctl(param)
+        assert actual == expected, f"{param} = {actual}, expected {expected}"
+```
+
+---
+
+## Mission Cross-Reference
+
+| Mission | Testing Focus |
+|---------|---------------|
+| 2.1 — Weapon Handling Test | Molecule deep dive, obstacle course (write tests, write roles to pass tests) |
+| 2.2 — Compliance as Code | CIS benchmark tests, Lynis integration, tagged compliance controls |
+| 2.3 — Fleet Sync | Testing rolling updates, delegation patterns, fleet-wide assertions |
+| Master Simulation | Full synthesis — build and test a complete hardening pipeline |
+
+---
+
+*FM-3 — Starfall Defence Corps Academy, 2187*

--- a/field-manuals/FM-4-cis-compliance-reference.md
+++ b/field-manuals/FM-4-cis-compliance-reference.md
@@ -1,0 +1,491 @@
+# FM-4: CIS & Compliance Reference
+> Starfall Defence Corps — Field Manual
+
+---
+
+A fleet that ignores its own hardening standards is already compromised. CIS Benchmarks are the baseline — the minimum acceptable posture for any vessel in active service. This manual maps those benchmarks to Ansible automation so you can enforce them at scale, verify them with Lynis, and tag them for selective deployment.
+
+---
+
+## What CIS Benchmarks Are
+
+The Centre for Internet Security (CIS) publishes consensus-driven configuration baselines for operating systems, cloud platforms, and applications. These are not opinions — they are vetted by hundreds of security professionals and updated with each OS release.
+
+Every CIS Benchmark is split into two levels:
+
+| Level | Meaning | Impact |
+|-------|---------|--------|
+| **Level 1** | Essential hardening. Low risk of breaking functionality. Every system should meet this bar. | Minimal operational disruption |
+| **Level 2** | Defence-in-depth. May restrict functionality. Applied where the threat model demands it. | May require application-level changes |
+
+### How Controls Are Numbered
+
+Controls follow a hierarchical numbering scheme: `Section.Subsection.Control`.
+
+```
+5.2.4 — Section 5 (Access/Auth), Subsection 2 (SSH Server), Control 4 (Root Login)
+```
+
+Each control includes a description, rationale, audit procedure (how to check), and remediation (how to fix). Your Ansible tasks are the automated remediation. Your Molecule tests are the automated audit.
+
+---
+
+## CIS to Ansible Mapping — Ubuntu 22.04
+
+The following tables map specific CIS controls to Ansible implementations. Each example is a working task you can drop into a playbook. These cover the controls most relevant to the SDC curriculum.
+
+### Section 1 — Initial Setup
+
+| Control | Description | Ansible Module | Level |
+|---------|-------------|----------------|-------|
+| 1.5.1 | Core dumps restricted | `ansible.builtin.copy` | 1 |
+| 1.7.1 | Warning banner configured | `ansible.builtin.copy` | 1 |
+
+**1.5.1 — Restrict Core Dumps**
+
+Core dumps can leak credentials and encryption keys from memory. Disable them fleet-wide.
+
+```yaml
+- name: "CIS 1.5.1 — Restrict core dumps"
+  ansible.builtin.copy:
+    dest: /etc/security/limits.d/99-core-dump.conf
+    content: "* hard core 0\n"
+    mode: "0644"
+  tags: [cis, cis_1, cis_1_5_1]
+```
+
+**1.7.1 — Warning Banner**
+
+Legal warning banners deter unauthorised access and satisfy audit requirements.
+
+```yaml
+- name: "CIS 1.7.1 — Deploy login warning banner"
+  ansible.builtin.copy:
+    dest: /etc/issue.net
+    content: |
+      *** STARFALL DEFENCE CORPS — AUTHORISED PERSONNEL ONLY ***
+      Unauthorised access is a violation of SDC Regulation 7-14.
+    mode: "0644"
+  tags: [cis, cis_1, cis_1_7_1]
+```
+
+### Section 3 — Network Configuration
+
+| Control | Description | Ansible Module | Level |
+|---------|-------------|----------------|-------|
+| 3.1.1 | IP forwarding disabled | `ansible.posix.sysctl` | 1 |
+| 3.3.2 | ICMP redirects not accepted | `ansible.posix.sysctl` | 1 |
+| 3.3.3 | Secure ICMP redirects not accepted | `ansible.posix.sysctl` | 1 |
+| 3.3.4 | Suspicious packets logged | `ansible.posix.sysctl` | 1 |
+
+**3.1.1 — Disable IP Forwarding**
+
+Unless a node is explicitly a router, IP forwarding is a lateral-movement vector.
+
+```yaml
+- name: "CIS 3.1.1 — Disable IP forwarding"
+  ansible.posix.sysctl:
+    name: net.ipv4.ip_forward
+    value: "0"
+    sysctl_set: true
+    reload: true
+  tags: [cis, cis_3, cis_3_1_1]
+```
+
+**3.3.2 — Reject ICMP Redirects**
+
+ICMP redirects can be used to manipulate routing tables. Reject them on all interfaces.
+
+```yaml
+- name: "CIS 3.3.2 — Do not accept ICMP redirects"
+  ansible.posix.sysctl:
+    name: "{{ item }}"
+    value: "0"
+    sysctl_set: true
+    reload: true
+  loop:
+    - net.ipv4.conf.all.accept_redirects
+    - net.ipv4.conf.default.accept_redirects
+  tags: [cis, cis_3, cis_3_3_2]
+```
+
+**3.3.3 — Reject Secure ICMP Redirects**
+
+Even "secure" ICMP redirects are a risk on hosts that are not routers.
+
+```yaml
+- name: "CIS 3.3.3 — Do not accept secure ICMP redirects"
+  ansible.posix.sysctl:
+    name: "{{ item }}"
+    value: "0"
+    sysctl_set: true
+    reload: true
+  loop:
+    - net.ipv4.conf.all.secure_redirects
+    - net.ipv4.conf.default.secure_redirects
+  tags: [cis, cis_3, cis_3_3_3]
+```
+
+**3.3.4 — Log Suspicious Packets**
+
+Martian packets (impossible source addresses) indicate reconnaissance or spoofing. Log them.
+
+```yaml
+- name: "CIS 3.3.4 — Log suspicious packets"
+  ansible.posix.sysctl:
+    name: "{{ item }}"
+    value: "1"
+    sysctl_set: true
+    reload: true
+  loop:
+    - net.ipv4.conf.all.log_martians
+    - net.ipv4.conf.default.log_martians
+  tags: [cis, cis_3, cis_3_3_4]
+```
+
+### Section 5 — Access, Authentication, and Authorisation
+
+| Control | Description | Ansible Module | Level |
+|---------|-------------|----------------|-------|
+| 5.1.8 | Cron restricted to authorised users | `ansible.builtin.copy` | 1 |
+| 5.2.4 | SSH root login disabled | `ansible.builtin.lineinfile` | 1 |
+| 5.2.5 | SSH password auth disabled | `ansible.builtin.lineinfile` | 1 |
+| 5.2.7 | SSH MaxAuthTries set to 4 or fewer | `ansible.builtin.lineinfile` | 1 |
+| 5.2.13 | SSH ClientAliveInterval configured | `ansible.builtin.lineinfile` | 1 |
+| 5.2.16 | SSH LoginGraceTime set to 60 or less | `ansible.builtin.lineinfile` | 1 |
+
+**5.1.8 — Restrict Cron to Authorised Users**
+
+Only explicitly authorised accounts should schedule tasks.
+
+```yaml
+- name: "CIS 5.1.8 — Restrict cron to authorised users"
+  ansible.builtin.copy:
+    dest: /etc/cron.allow
+    content: "root\n"
+    owner: root
+    group: root
+    mode: "0600"
+  tags: [cis, cis_5, cis_5_1_8]
+```
+
+**5.2.4 — Disable SSH Root Login**
+
+Root login over SSH bypasses audit trails. Force operators to authenticate as themselves, then escalate.
+
+```yaml
+- name: "CIS 5.2.4 — Disable SSH root login"
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '^#?PermitRootLogin'
+    line: "PermitRootLogin no"
+  notify: Restart sshd
+  tags: [cis, cis_5, cis_5_2_4]
+```
+
+**5.2.5 — Disable SSH Password Authentication**
+
+Key-based authentication eliminates brute-force risk entirely.
+
+```yaml
+- name: "CIS 5.2.5 — Disable SSH password authentication"
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '^#?PasswordAuthentication'
+    line: "PasswordAuthentication no"
+  notify: Restart sshd
+  tags: [cis, cis_5, cis_5_2_5]
+```
+
+**5.2.7 — Limit SSH MaxAuthTries**
+
+Restricting authentication attempts slows brute-force attacks and triggers fail2ban sooner.
+
+```yaml
+- name: "CIS 5.2.7 — Set SSH MaxAuthTries"
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '^#?MaxAuthTries'
+    line: "MaxAuthTries 4"
+  notify: Restart sshd
+  tags: [cis, cis_5, cis_5_2_7]
+```
+
+**5.2.13 — SSH ClientAliveInterval**
+
+Idle sessions are hijacking targets. Terminate them automatically.
+
+```yaml
+- name: "CIS 5.2.13 — Set SSH ClientAliveInterval"
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '^#?ClientAliveInterval'
+    line: "ClientAliveInterval 300"
+  notify: Restart sshd
+  tags: [cis, cis_5, cis_5_2_13]
+```
+
+**5.2.16 — SSH LoginGraceTime**
+
+Reduce the window for unauthenticated connections to consume resources.
+
+```yaml
+- name: "CIS 5.2.16 — Set SSH LoginGraceTime"
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '^#?LoginGraceTime'
+    line: "LoginGraceTime 60"
+  notify: Restart sshd
+  tags: [cis, cis_5, cis_5_2_16]
+```
+
+### Section 6 — System Maintenance
+
+| Control | Description | Ansible Module | Level |
+|---------|-------------|----------------|-------|
+| 6.1.3 | /etc/shadow permissions | `ansible.builtin.file` | 1 |
+| 6.1.4 | /etc/gshadow permissions | `ansible.builtin.file` | 1 |
+
+**6.1.3 — /etc/shadow Permissions**
+
+Password hashes are high-value targets. Lock down the shadow file.
+
+```yaml
+- name: "CIS 6.1.3 — Set /etc/shadow permissions"
+  ansible.builtin.file:
+    path: /etc/shadow
+    owner: root
+    group: shadow
+    mode: "0640"
+  tags: [cis, cis_6, cis_6_1_3]
+```
+
+**6.1.4 — /etc/gshadow Permissions**
+
+Same principle as shadow — group password hashes must be protected.
+
+```yaml
+- name: "CIS 6.1.4 — Set /etc/gshadow permissions"
+  ansible.builtin.file:
+    path: /etc/gshadow
+    owner: root
+    group: shadow
+    mode: "0640"
+  tags: [cis, cis_6, cis_6_1_4]
+```
+
+---
+
+## CIS to Ansible Mapping — Rocky Linux 9 Differences
+
+Rocky Linux 9 shares most CIS controls with Ubuntu 22.04, but the underlying tools and paths diverge. Know the differences before you write cross-platform playbooks.
+
+| Area | Ubuntu 22.04 | Rocky Linux 9 |
+|------|--------------|---------------|
+| **Package manager** | `ansible.builtin.apt` | `ansible.builtin.dnf` |
+| **Firewall tool** | `ufw` / `community.general.ufw` | `firewalld` / `ansible.posix.firewalld` |
+| **SSH service name** | `ssh` (or `sshd`) | `sshd` |
+| **Shadow group** | `shadow` | `root` |
+| **Cron package** | `cron` | `cronie` |
+| **Sysctl path** | `/etc/sysctl.d/` | `/etc/sysctl.d/` (same) |
+| **SELinux** | Not present (AppArmor) | Enforcing by default — do not disable |
+| **CIS section numbering** | Ubuntu-specific benchmark | RHEL 9 benchmark (different control IDs in places) |
+
+### Key Implementation Differences
+
+**Shadow file group ownership** differs. Handle it with a conditional:
+
+```yaml
+- name: "CIS 6.1.3 — Set /etc/shadow permissions"
+  ansible.builtin.file:
+    path: /etc/shadow
+    owner: root
+    group: "{{ 'shadow' if ansible_os_family == 'Debian' else 'root' }}"
+    mode: "0640"
+  tags: [cis, cis_6, cis_6_1_3]
+```
+
+**Firewall rules** require entirely different modules. Use `when` conditionals or separate task files:
+
+```yaml
+- name: "Allow SSH — Ubuntu"
+  community.general.ufw:
+    rule: allow
+    port: "22"
+    proto: tcp
+  when: ansible_os_family == "Debian"
+
+- name: "Allow SSH — Rocky"
+  ansible.posix.firewalld:
+    service: ssh
+    permanent: true
+    state: enabled
+    immediate: true
+  when: ansible_os_family == "RedHat"
+```
+
+**SELinux** on Rocky must remain enforcing. CIS for RHEL 9 explicitly requires it. If your playbook disables SELinux, you are failing the benchmark, not passing it.
+
+---
+
+## Lynis Quick Reference
+
+Lynis is an open-source security auditing tool. It performs a system scan and produces a hardening index — a numerical score reflecting how many controls the host satisfies. Use it as a before/after metric when applying CIS remediations.
+
+### Installation
+
+```yaml
+# Ubuntu
+- name: Install Lynis
+  ansible.builtin.apt:
+    name: lynis
+    state: present
+
+# Rocky
+- name: Install Lynis
+  ansible.builtin.dnf:
+    name: lynis
+    state: present
+```
+
+### Running a Scan
+
+From the command line:
+
+```bash
+sudo lynis audit system --quick --no-colors
+```
+
+The `--quick` flag skips interactive prompts. `--no-colors` produces clean output for parsing and logging.
+
+### Running via Ansible Ad-Hoc
+
+Scan all hosts in your inventory without writing a playbook:
+
+```bash
+ansible all -m ansible.builtin.command \
+  -a "lynis audit system --quick --no-colors" \
+  -b --become
+```
+
+Or target a specific group:
+
+```bash
+ansible webservers -m ansible.builtin.command \
+  -a "lynis audit system --quick --no-colors" \
+  -b --become
+```
+
+### Reading the Hardening Index
+
+Lynis outputs a score between 0 and 100 at the end of its report:
+
+```
+Hardening index : 67 [#############       ]
+```
+
+| Score Range | Assessment |
+|-------------|------------|
+| 0–49 | Critical — immediate remediation required |
+| 50–69 | Below standard — significant gaps remain |
+| 70–84 | Acceptable — meets minimum fleet requirements |
+| 85–100 | Hardened — exceeds baseline, ready for hostile sectors |
+
+### Interpreting Results
+
+Lynis categorises findings into three types:
+
+| Symbol | Meaning | Action |
+|--------|---------|--------|
+| `[WARNING]` | Active vulnerability or misconfiguration | Fix immediately |
+| `[SUGGESTION]` | Hardening opportunity, not critical | Evaluate and apply where appropriate |
+| `[OK]` | Control satisfied | No action needed |
+
+The full report is written to `/var/log/lynis-report.dat`. Parse it programmatically:
+
+```bash
+grep "suggestion\[\]" /var/log/lynis-report.dat | sort -u
+```
+
+---
+
+## CIS vs STIG
+
+Two compliance frameworks dominate the security hardening space. Know which one applies to your mission.
+
+| Dimension | CIS Benchmark | DISA STIG |
+|-----------|---------------|-----------|
+| **Publisher** | Centre for Internet Security | Defence Information Systems Agency (DoD) |
+| **Audience** | Industry-wide, any organisation | US Department of Defence and contractors |
+| **Strictness** | Moderate — Level 1 is broadly safe | High — assumes hostile threat environment |
+| **Licensing** | Free PDF download | Free, publicly available |
+| **Levels** | Level 1 (baseline), Level 2 (defence-in-depth) | CAT I (critical), CAT II (medium), CAT III (low) |
+| **Update cycle** | Per OS release | Per OS release + quarterly updates |
+| **Audit tool** | Lynis, OpenSCAP | SCAP Compliance Checker (SCC), OpenSCAP |
+| **Ansible tooling** | Manual or community roles | `ansible-lockdown` project provides STIG roles |
+| **SDC usage** | Missions 2.2, Master Simulation | Reference only — CIS is the SDC standard |
+
+**When to use CIS**: Default choice. Covers the vast majority of hardening requirements without restricting operational functionality. The SDC curriculum is built on CIS.
+
+**When to use STIG**: When operating in environments that mandate DoD compliance, or when the threat model calls for maximum restriction at the cost of operational flexibility.
+
+---
+
+## Ansible Tags for CIS
+
+Tagging every CIS task allows selective enforcement. When a scan reveals a single failing control, you should not need to re-run the entire hardening playbook — target the specific section.
+
+### Tagging Convention
+
+Apply three levels of tags to every CIS task:
+
+```yaml
+tags: [cis, cis_5, cis_5_2_4]
+#      ^     ^       ^
+#      |     |       +-- Specific control
+#      |     +---------- Section
+#      +---------------- All CIS tasks
+```
+
+### Running Selective Controls
+
+Apply only SSH hardening (Section 5.2):
+
+```bash
+ansible-playbook harden.yml --tags cis_5
+```
+
+Apply a single control:
+
+```bash
+ansible-playbook harden.yml --tags cis_5_2_4
+```
+
+Apply everything except network configuration:
+
+```bash
+ansible-playbook harden.yml --tags cis --skip-tags cis_3
+```
+
+### Combining Tags with Check Mode
+
+Audit without changing anything — report what would be remediated:
+
+```bash
+ansible-playbook harden.yml --tags cis --check --diff
+```
+
+This is the Ansible equivalent of a Lynis scan: it tells you what is out of compliance without modifying the system. Use it before applying changes to production vessels.
+
+---
+
+## Mission References
+
+| Mission | Relevance |
+|---------|-----------|
+| **2.2 — Compliance as Code** | CIS benchmarks deep dive. Lynis scanning. Tagged controls. First mission where you enforce CIS at scale. |
+| **Master Simulation** | Full CIS compliance across 6 nodes. Multi-OS. Everything in this manual applied under pressure. |
+
+---
+
+*Filed under SDC Academy Field Manuals. Consult FM-1 for module details, FM-3 for Molecule testing of compliance tasks.*

--- a/field-manuals/FM-5-glossary.md
+++ b/field-manuals/FM-5-glossary.md
@@ -1,0 +1,162 @@
+# FM-5: Glossary
+> Starfall Defence Corps -- Field Manual
+
+Classification: UNCLASSIFIED // Training Use Only
+Revision: 1.0 | Date: 2187.04.03
+
+---
+
+Combined technical and lore glossary for the SDC Academy curriculum. Entries are alphabetical. Where a term maps to an in-universe equivalent, both are noted.
+
+---
+
+## A
+
+**Ad-hoc command** -- A one-off Ansible command run directly from the command line without writing a playbook. Uses the `ansible` binary with `-m` (module) and `-a` (arguments). Useful for quick inspections and emergency fixes, but not repeatable or auditable the way playbooks are. -- *First introduced: Mission 1.1*
+
+**ansible.cfg** -- The Ansible configuration file. Controls defaults such as inventory path, remote user, privilege escalation, and SSH options. Ansible searches for it in the current directory, the home directory, or `/etc/ansible/`. Each mission workspace ships one pre-configured for the lab environment.
+
+**Ansible Vault** -- Ansible's built-in encryption system for protecting sensitive data (passwords, API keys, certificates). Files are encrypted with AES-256 using a vault password. In SDC lore, the Vault is referred to as the **Crypto Cell**. -- *First introduced: Mission 1.5*
+
+**ansible-lint** -- A static analysis tool that checks playbooks, roles, and task files for style violations, anti-patterns, and potential errors. Enforces best practices such as using FQCNs and naming every task. Central to CI/CD pipeline enforcement. -- *First introduced: Mission 2.4*
+
+**ARIA (Automated Review & Intelligence Analyst)** -- The SDC Academy's AI-powered code reviewer. ARIA runs as a GitHub Action on student pull requests, analysing playbooks against mission-specific criteria and returning a structured debrief. Personality: formal, terse, military-analytical. Never praises without evidence.
+
+## B
+
+**Become** -- Ansible's privilege escalation mechanism. When `become: true` is set, tasks execute as a privileged user (default: root) via `sudo`. Configured per play, per task, or globally in `ansible.cfg`. See also: **Privilege escalation**.
+
+**Block / Rescue / Always** -- Ansible's error-handling structure, analogous to try/catch/finally. `block` wraps a set of tasks, `rescue` runs if any task in the block fails, and `always` runs regardless of outcome. Essential for safe rolling updates. -- *First introduced: Mission 2.3*
+
+## C
+
+**Cadet / Ensign / Lieutenant JG / Lieutenant / Lt. Commander** -- SDC Academy rank progression. Cadets begin at Mission 1.1. Promotion occurs upon completing mission milestones: Ensign (after 1.2), Lieutenant JG (after 1.5), Lieutenant (after the Gateway Simulation), Lt. Commander (after the Master Simulation).
+
+**Captain Unpatched** -- Lore villain. A negligent commanding officer whose ships run outdated software with known CVEs. Represents the threat of unpatched systems and ignored compliance baselines. -- *First introduced: Mission 2.2*
+
+**CI/CD Pipeline** -- Continuous Integration / Continuous Delivery. An automated workflow (typically GitHub Actions) that runs linting, syntax checks, and Molecule tests on every push or pull request. Catches configuration errors before they reach production. -- *First introduced: Mission 2.4*
+
+**CIS Benchmark** -- A set of security configuration guidelines published by the Center for Internet Security. Provides prescriptive, consensus-based hardening standards for operating systems, services, and applications. SDC missions implement a subset of CIS controls via Ansible. -- *First introduced: Mission 2.2*
+
+**Collection** -- A distribution format for Ansible content (modules, roles, plugins). Academy missions rely on `ansible.posix` (for `sysctl`, `firewalld`, `authorized_key`) and `community.general` (for `ufw` and others). Installed via `ansible-galaxy collection install`.
+
+**Colonel Hardcoded-Password** -- Lore villain. An officer who stores credentials in plaintext across every ship in the fleet. Represents secrets committed to version control and unencrypted variable files. -- *First introduced: Mission 1.5*
+
+**Conditionals / when clause** -- Ansible's mechanism for running tasks only when a condition is true. Uses Jinja2 expressions evaluated at runtime (e.g., `when: ansible_os_family == "Debian"`). Critical for writing multi-OS playbooks. -- *First introduced: Mission 1.4*
+
+**Configuration drift** -- The gradual divergence of a system's actual state from its desired state, caused by manual changes, ad-hoc fixes, or missed automation runs. Detected by scheduled Molecule tests or periodic playbook runs with `--check --diff`. -- *First introduced: Mission 2.4*
+
+**Converge** -- A Molecule test phase that applies the role or playbook under test to the target container. This is where Ansible actually runs. Preceded by `create` (spin up containers) and followed by `verify` (run assertions). -- *First introduced: Mission 2.1*
+
+**Corporal Copy-Paste** -- Lore villain. A technician who duplicates configuration blocks across ships instead of using variables and templates. Represents hardcoded values, copy-paste errors, and lack of abstraction. -- *First introduced: Mission 1.4*
+
+**Crypto Cell** -- SDC lore term for Ansible Vault. The secure compartment aboard each vessel where encrypted credentials and classified configuration data are stored. See: **Ansible Vault**. -- *First introduced: Mission 1.5*
+
+## D
+
+**delegate_to** -- An Ansible task directive that executes the task on a different host than the current play target. Used for orchestration patterns such as removing a node from a load balancer before updating it, or running a health check from a monitoring server. -- *First introduced: Mission 2.3*
+
+## F
+
+**Facts** -- System information automatically gathered by Ansible at the start of each play (unless disabled). Includes OS family, IP addresses, memory, disk layout, and more. Accessed as variables (e.g., `ansible_distribution`). See also: **Gather facts**. -- *First introduced: Mission 1.1*
+
+## G
+
+**Gather facts** -- The implicit first task of every Ansible play (unless `gather_facts: false`). Runs the `setup` module on each target host and populates the `ansible_*` variable namespace. Can be expensive on large inventories; disable when facts are not needed.
+
+**Gateway Simulation / Operation: First Contact** -- The Module 1 capstone exercise. A timed 75-minute simulation that combines inventory management, SSH hardening, service control, multi-OS configuration, and role-based organisation into a single scenario. Passing earns the rank of Lieutenant.
+
+**General Snowflake** -- Lore villain of the Master Simulation. A flag officer who insists every ship in the fleet be configured by hand, rejecting automation and standardisation. Represents the ultimate anti-pattern: unique, unreproducible infrastructure.
+
+**group_vars** -- A directory containing YAML files that define variables applying to all hosts in a named inventory group. File names match group names (e.g., `group_vars/webservers.yml`). Higher specificity than `all` group vars, lower than `host_vars`. -- *First introduced: Mission 1.4*
+
+## H
+
+**Handler** -- A special Ansible task that runs only when notified by another task. Typically used for service restarts or reloads after configuration changes. Handlers run once at the end of the play, regardless of how many tasks notify them. -- *First introduced: Mission 1.2*
+
+**Hardening index** -- A numerical score (0--100) produced by Lynis representing the overall security posture of a system. Used in SDC missions as the measurable target: students must raise the index above a specified threshold. -- *First introduced: Mission 2.2*
+
+**host_vars** -- A directory containing YAML files that define variables for individual hosts. File names match inventory hostnames. Highest specificity in the directory-based variable hierarchy, overriding `group_vars`.
+
+## I
+
+**Idempotency** -- The property that running the same operation multiple times produces the same result as running it once. In Ansible, a well-written playbook should report `changed=0` on subsequent runs. This is the core design principle tested in every SDC mission.
+
+**Inventory** -- A file or directory that defines the hosts and groups Ansible manages. Can be INI or YAML format, static or dynamic. The inventory is the map of your fleet. -- *First introduced: Mission 1.1*
+
+**Iron Curtain** -- The badge awarded upon completing the Master Simulation (Operation: Iron Curtain). Represents mastery of automated compliance enforcement across a heterogeneous fleet under adversarial conditions.
+
+## J
+
+**Jinja2 template** -- A text file containing Jinja2 expressions (`{{ variable }}`, `{% if %}`, `{% for %}`) that Ansible renders into host-specific output. Used with the `ansible.builtin.template` module to generate configuration files dynamically. -- *First introduced: Mission 1.4*
+
+## L
+
+**Lint / linting** -- The process of statically analysing code for style issues, anti-patterns, and errors without executing it. In the SDC context, `ansible-lint` and `yamllint` are the primary tools, enforced in CI pipelines. -- *First introduced: Mission 2.4*
+
+**Lynis** -- An open-source security auditing tool for Unix-based systems. Performs hundreds of individual tests covering authentication, file permissions, kernel parameters, networking, and more. Produces a hardening index score. -- *First introduced: Mission 2.2*
+
+## M
+
+**Master Simulation / Operation: Iron Curtain** -- The Module 2 capstone. A comprehensive scenario requiring students to enforce CIS-aligned hardening across a mixed-OS fleet, implement CI/CD pipelines, handle rolling updates, and defeat General Snowflake's manual-configuration doctrine.
+
+**max_fail_percentage** -- An Ansible play-level setting that stops execution when the percentage of failed hosts exceeds the threshold. Prevents a bad update from propagating across the entire fleet. Works in conjunction with `serial`. -- *First introduced: Mission 2.3*
+
+**Module** -- A unit of code that Ansible executes on managed hosts. Modules handle specific tasks (installing packages, managing files, controlling services). Always reference by fully qualified collection name (FQCN) in playbooks (e.g., `ansible.builtin.copy`, not `copy`).
+
+**Molecule** -- A testing framework for Ansible roles and playbooks. Provides a workflow of create, converge, verify, and destroy phases using ephemeral Docker containers. The standard testing tool across all SDC missions. -- *First introduced: Mission 2.1*
+
+## N
+
+**Notify** -- A task-level directive that triggers a named handler when the task reports a change. Multiple notifications to the same handler result in a single handler execution. -- *First introduced: Mission 1.2*
+
+## P
+
+**Play / Playbook** -- A play is a mapping of hosts to tasks. A playbook is a YAML file containing one or more plays. Playbooks are the primary unit of Ansible automation -- repeatable, version-controlled, and auditable. -- *First introduced: Mission 1.2*
+
+**Private YOLO-Deploy** -- Lore villain. A reckless operator who pushes untested changes directly to production with no CI checks, no Molecule tests, and no rollback plan. Represents the absence of testing discipline and deployment safeguards. -- *First introduced: Mission 2.1*
+
+**Privilege escalation / become** -- The mechanism by which Ansible elevates permissions on a managed host. The `become` directive uses `sudo` by default. Can be scoped to an entire play or individual tasks. See: **Become**.
+
+## R
+
+**Role** -- An Ansible content unit that bundles tasks, handlers, templates, files, variables, and defaults into a reusable, shareable directory structure. Roles enforce separation of concerns and are the standard way to organise non-trivial automation. -- *First introduced: Mission 1.5*
+
+**Rolling update / serial** -- A deployment strategy where only a subset of hosts are updated at a time (controlled by the `serial` keyword). Maintains fleet availability during updates by ensuring some hosts remain operational. -- *First introduced: Mission 2.3*
+
+**run_once** -- An Ansible task directive that ensures a task executes on only one host in the play, regardless of how many hosts are targeted. Useful for one-time actions like database migrations or control-plane commands. -- *First introduced: Mission 2.3*
+
+## S
+
+**SDC (Starfall Defence Corps)** -- The interstellar military organisation responsible for defending human-colonised systems against the Voidborn. Students are cadets enrolled in the SDC Academy, training to become fleet automation engineers.
+
+**SSH Root Fairy** -- Lore villain. A mythical being who leaves root login enabled and password authentication wide open on every ship. Represents the most basic SSH misconfiguration: allowing direct root access over the network. -- *First introduced: Mission 1.2*
+
+**STIG (Security Technical Implementation Guide)** -- A set of security hardening standards published by DISA (Defense Information Systems Agency). More prescriptive and US-DoD-specific than CIS Benchmarks. Referenced in SDC lore as the military-grade counterpart to CIS controls.
+
+**sysctl** -- A Linux kernel interface for modifying runtime parameters (e.g., IP forwarding, SYN cookies, ICMP redirects). Managed in Ansible via `ansible.posix.sysctl`. Persistent changes require entries in `/etc/sysctl.d/`. -- *First introduced: Mission 1.3*
+
+## T
+
+**Tag** -- An Ansible metadata label applied to tasks, roles, or plays. Allows selective execution with `--tags` or `--skip-tags`. In compliance work, tags map to specific CIS control numbers for targeted remediation. -- *First introduced: Mission 2.2*
+
+**Task** -- The smallest unit of work in Ansible. A task calls a single module with specific parameters. Tasks execute sequentially within a play and report one of: ok, changed, failed, or skipped.
+
+**Template** -- See: **Jinja2 template**. The `ansible.builtin.template` module renders a Jinja2 source file and deploys the result to the managed host. -- *First introduced: Mission 1.4*
+
+**Testinfra** -- A Python testing framework (pytest plugin) for validating the state of servers. Used in Molecule's verify phase to assert that packages are installed, services are running, ports are listening, and files have correct permissions. -- *First introduced: Mission 2.1*
+
+## V
+
+**Variable precedence** -- The order in which Ansible resolves conflicting variable definitions. There are 22 levels of precedence (from lowest: command-line defaults, to highest: extra vars via `-e`). Understanding precedence prevents unexpected overrides. Key levels for SDC missions: role defaults < `group_vars` < `host_vars` < play vars < extra vars.
+
+**Vault password file** -- A plaintext file containing the password used to decrypt Ansible Vault-encrypted files. Referenced in `ansible.cfg` via `vault_password_file`. Must never be committed to version control. Note: if the file does not exist, all Ansible commands will fail. -- *First introduced: Mission 1.5*
+
+**Verify** -- A Molecule test phase that runs Testinfra (or another verifier) to assert the managed host is in the desired state after converge. This is where pass/fail is determined. -- *First introduced: Mission 2.1*
+
+**Voidborn** -- The existential threat to human-colonised space. An alien intelligence that exploits misconfigured systems, unpatched vulnerabilities, and poor operational hygiene to infiltrate fleet networks. Every SDC mission is framed as defending against Voidborn incursion.
+
+---
+
+*"Know the words, know the war. Terminology is the first line of defence against ambiguity -- and ambiguity is how the Voidborn get in."*
+-- ARIA, orientation address to incoming cadets

--- a/field-manuals/FM-6-faq-simulation-hub.md
+++ b/field-manuals/FM-6-faq-simulation-hub.md
@@ -1,0 +1,127 @@
+# FM-6: FAQ & Simulation Hub
+> Starfall Defence Corps — Field Manual
+
+---
+
+## Frequently Asked Questions
+
+---
+
+### 1. Why Ansible?
+
+Ansible is agentless — nothing to install on target systems, nothing to maintain, nothing for the Voidborn to exploit. It speaks YAML, not a proprietary DSL. It is the dominant automation tool in defence and government environments for exactly these reasons. If you are hardening a fleet, Ansible is the weapon.
+
+### 2. Do I need to know how to code?
+
+No. YAML is structured data, not a programming language. If you can write a bulleted list with consistent indentation, you can write a playbook. Familiarity with the command line will help, but you do not need to be a developer.
+
+### 3. Why Molecule?
+
+"I ran it and it looked fine" is how General Snowflake operated, and we all know how that ended. Molecule gives you automated, repeatable proof that your infrastructure code works. It spins up containers, applies your role, runs assertions, and tears everything down. No human eyeballs required.
+
+### 4. CIS vs STIG — what's the difference?
+
+CIS benchmarks are industry consensus — developed by a global community, available to anyone, and the standard starting point for hardening. STIGs are DoD mandates — required for military and government systems, more prescriptive, and more painful. Defence organisations use STIGs. Everyone else starts with CIS Level 1 and works up from there.
+
+### 5. Can I use this at work?
+
+Everything in this curriculum uses open-source tools, publicly available benchmarks, and production-ready patterns. The techniques are the same ones used in real security operations. Swap "Voidborn" for your actual threat model and "fleet" for your actual inventory.
+
+### 6. I'm not military — is this relevant?
+
+The military framing is flavour. "Mission" instead of "lab exercise." "Fleet" instead of "server group." The skills underneath — hardening, compliance-as-code, automated testing, rolling deployments, drift detection — are universal. Every organisation with servers needs them.
+
+### 7. How is this different from other Ansible courses?
+
+Every example is security-focused. You will never "install nginx and serve a web page." Testing is core curriculum, not an afterthought. Git workflow is baked into every mission. You will learn to harden, verify, and automate — not just configure.
+
+### 8. What tools do I need?
+
+Docker Desktop, GNU Make, Python 3.10+, and Git. All free, all cross-platform. Windows users need WSL2. That is the entire toolchain. No paid licenses, no cloud accounts, no proprietary platforms.
+
+### 9. How long does the full course take?
+
+Module 1 (Missions 1.1–1.5): approximately 6–8 hours. Module 2 (Missions 2.1–2.4): approximately 8–12 hours. Gateway Simulation: 75 minutes. Master Simulation: 3.5 hours. Total curriculum: roughly 20–25 hours depending on your pace.
+
+### 10. What rank do I earn?
+
+You begin at **Cadet**. Completing Module 1 and the Gateway Simulation earns **Ensign**. Module 2 missions progress you through **Lieutenant JG** and **Lieutenant**. Completing the Master Simulation earns **Lt. Commander**. Each rank is earned, not given.
+
+### 11. Can I skip ahead?
+
+Each mission builds directly on skills from the previous one. Mission 1.4 assumes you can write a playbook (1.2) and manage services (1.3). The simulations test everything at once. Skipping missions leaves gaps, and the simulations will expose them.
+
+### 12. What if ARIA fails my work?
+
+Read the ARIA output carefully — it tells you exactly what failed and why. Fix the identified issues, run `make test` again, and resubmit. There is no penalty for retries. ARIA is not here to punish you. She is here to make sure your work is correct before it reaches production.
+
+---
+
+## Simulation Hub
+
+---
+
+All simulations are timed, proctored by ARIA, and designed to test accumulated skills under pressure. There is no partial credit. Every mission within a simulation must pass.
+
+| Simulation | Codename | Time | Skills Tested | Rank Earned | Repo |
+|------------|----------|------|---------------|-------------|------|
+| Gateway | Operation: First Contact | 75 min | All Module 1 (inventory, playbooks, roles, Vault, multi-OS) | Ensign | `gateway-simulation` |
+| Master | Operation: Iron Curtain | 3.5 hrs | All Module 2 (Molecule, CIS, rolling updates, CI/CD, incident response) | Lt. Commander | `master-simulation` |
+
+---
+
+### Gateway Simulation — Operation: First Contact
+
+**What to expect**: Three missions in 75 minutes. You inherit a compromised forward observation post — three nodes, SSH wide open, firewalls down, insecure services running. You will assess, harden, and encrypt. No hints file. No hand-holding. Everything from Module 1, applied under the clock.
+
+**Prerequisites**: Missions 1.1 through 1.5 completed. You must be comfortable with inventory, ad-hoc commands, playbooks, roles, handlers, templates, Vault, and multi-OS support.
+
+**How to attempt**:
+```bash
+git clone https://github.com/starfall-defence-corps/gateway-simulation.git
+cd gateway-simulation
+make setup
+source venv/bin/activate
+# Read docs/BRIEFING.md, start your timer, begin.
+```
+
+**Performance tiers**:
+
+| Total Time | Rating |
+|------------|--------|
+| Under 45 min | **Ace Cadet** |
+| 45–55 min | **Distinguished** |
+| 55–65 min | **Qualified** |
+| 65–75 min | **Passed** |
+| 75+ min | **RTB** (Return to Base — retry) |
+
+---
+
+### Master Simulation — Operation: Iron Curtain
+
+**What to expect**: Four missions in 3.5 hours. You inherit General Snowflake's hand-built fleet — six nodes, no compliance baseline, no tests, no automation. You will assess all six against CIS benchmarks with Lynis, build a tagged hardening role with Molecule tests, construct a CI/CD pipeline with drift detection, and respond to a live incident. This is everything.
+
+**Prerequisites**: All of Module 1, all of Module 2 (Missions 2.1 through 2.4), and the Gateway Simulation. You must be comfortable with Molecule, Testinfra, CIS controls, rolling updates, ansible-lint, CI pipelines, and incident investigation.
+
+**How to attempt**:
+```bash
+git clone https://github.com/starfall-defence-corps/master-simulation.git
+cd master-simulation
+make setup
+source venv/bin/activate
+# Read docs/BRIEFING.md, start your timer, begin.
+```
+
+**Performance tiers**:
+
+| Total Time | Rating |
+|------------|--------|
+| Under 2.5 hrs | **Outstanding** |
+| 2.5–3 hrs | **Excellent** |
+| 3–3.5 hrs | **Qualified** |
+| 3.5–4 hrs | **Passed** |
+| 4+ hrs | **Return to AIT** (retry) |
+
+---
+
+*SDC Cyber Command — 2187 — UNCLASSIFIED // Training Use Only*


### PR DESCRIPTION
## Summary
- FM-1: Ansible Module Reference — 24 blue team module cards with FQCN, examples, security use cases
- FM-2: YAML & Jinja2 Quick Reference — syntax, filters, common gotchas
- FM-3: Molecule & Testing Reference — lifecycle, Testinfra assertions, multi-platform patterns
- FM-4: CIS & Compliance Reference — CIS to Ansible mapping for Ubuntu 22.04 + Rocky 9
- FM-5: Glossary — 50+ technical and lore terms cross-referenced with missions
- FM-6: FAQ & Simulation Hub — 12 FAQs + simulation details with timing tiers

README updated with Field Manuals section.

Closes #3, #4, #5, #6, #7, #8

## Test plan
- [x] All 6 FM files created with consistent formatting
- [x] README links point to correct files
- [x] Cross-references to missions are accurate